### PR TITLE
Add missing synonyms for “Inexpedient”

### DIFF
--- a/js/word-data-set.js
+++ b/js/word-data-set.js
@@ -3094,7 +3094,7 @@ var words = [
     "word": "inexpedient",
     "definition": "not tending to the end desired, inadvisable, unfit, improper",
     "wordtype": "adjective",
-    "synonyms": ""
+    "synonyms": "counterproductive, feckless, hamstrung"
   },
   {
     "id": 3061,


### PR DESCRIPTION
Added three synonyms for “inexpedient”, which is missing a list of synonyms. These synonyms were extracted from Merriam Webster’s online dictionary.